### PR TITLE
Make prop-types declaration file a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   },
   "homepage": "https://github.com/trainline/react-skeletor#readme",
   "dependencies": {
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "@types/prop-types": "^15.5.1"
   },
   "peerDependencies": {
     "react": "^15.5.4 || ^16.0.0"
@@ -51,7 +52,6 @@
     "@types/enzyme": "^2.7.6",
     "@types/jest": "^19.2.2",
     "@types/prettier": "^1.7.0",
-    "@types/prop-types": "^15.5.1",
     "@types/react": "^16.0.19",
     "@types/react-dom": "^16.0.2",
     "@types/react-test-renderer": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,9 @@
   },
   "homepage": "https://github.com/trainline/react-skeletor#readme",
   "dependencies": {
-    "prop-types": "^15.5.10",
-    "@types/prop-types": "^15.5.1"
+    "@types/prop-types": "^15.5.1",
+    "@types/react": "^16.3.11",
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
     "react": "^15.5.4 || ^16.0.0"
@@ -52,7 +53,6 @@
     "@types/enzyme": "^2.7.6",
     "@types/jest": "^19.2.2",
     "@types/prettier": "^1.7.0",
-    "@types/react": "^16.0.19",
     "@types/react-dom": "^16.0.2",
     "@types/react-test-renderer": "^16.0.0",
     "@types/recompose": "^0.22.0",


### PR DESCRIPTION
## Description
Moved `@types/prop-types` from `devDependencies` to `dependencies`.

## Addressed issue #15 
TypeScript consumers of the library need this package due to the type export in `utils.d.ts`. Currently as it is a devDependency it is not included in a normal install and results in TS compiler errors.

I have followed the official suggestion [here](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#dependencies) of including it as a regular dependency.

>Our package exposes declarations from each of those, so any user of our [browserify-typescript-extension - react-skeletor] package needs to have these dependencies as well. For that reason, we used "dependencies" and not "devDependencies", because otherwise our consumers would have needed to manually install those packages.
