### PR TITLE
Attached displayName to skeleton elements

### DIFF
--- a/src/__tests__/createSkeletonElement.test.tsx
+++ b/src/__tests__/createSkeletonElement.test.tsx
@@ -25,7 +25,7 @@ describe('createSkeletonElement', () => {
     )(createSkeletonElement('span'));
 
     const wrapper = mount(<SpanWithContext>Hello world</SpanWithContext>);
-    expect(wrapper.find('span').text()).toBe('Hello world');
+    expect(wrapper.find('span').at(1).text()).toBe('Hello world');
   });
 
   it('should merge styles from context and props', () => {
@@ -42,7 +42,7 @@ describe('createSkeletonElement', () => {
     )(createSkeletonElement('div'));
     const wrapper = mount(<DivWithContext style={{ position: 'absolute' }} />);
 
-    expect(wrapper.find('div').props().style).toEqual({
+    expect(wrapper.find('div').at(1).props().style).toEqual({
       position: 'absolute',
       left: 0,
       right: 0,
@@ -65,7 +65,7 @@ describe('createSkeletonElement', () => {
     )(createSkeletonElement('div'));
     const wrapper = mount(<DivWithContext className="anotherHelloWorld" />);
 
-    expect(wrapper.find('div').props().className).toEqual(
+    expect(wrapper.find('div').at(1).props().className).toEqual(
       'anotherHelloWorld helloWorld'
     );
   });
@@ -84,7 +84,7 @@ describe('createSkeletonElement', () => {
     )(createSkeletonElement('div'));
     const wrapper = mount(<DivWithContext className="anotherHelloWorld" />);
 
-    expect(wrapper.find('div').props().className).toEqual(
+    expect(wrapper.find('div').at(1).props().className).toEqual(
       'anotherHelloWorld helloWorld'
     );
   });
@@ -102,7 +102,7 @@ describe('createSkeletonElement', () => {
     )(createSkeletonElement('div', { backgroundColor: 'black' }));
     const wrapper = mount(<DivWithContext />);
 
-    expect(wrapper.find('div').props().style).toEqual({
+    expect(wrapper.find('div').at(1).props().style).toEqual({
       backgroundColor: 'black'
     });
   });
@@ -120,7 +120,7 @@ describe('createSkeletonElement', () => {
     )(createSkeletonElement('div', 'aClassName'));
     const wrapper = mount(<DivWithContext />);
 
-    expect(wrapper.find('div').props().className).toEqual('aClassName');
+    expect(wrapper.find('div').at(1).props().className).toEqual('aClassName');
   });
 
   it('should accept function to style', () => {
@@ -136,7 +136,7 @@ describe('createSkeletonElement', () => {
     )(createSkeletonElement('div', () => 'aClassName'));
     const wrapper = mount(<DivWithContext />);
 
-    expect(wrapper.find('div').props().className).toEqual('aClassName');
+    expect(wrapper.find('div').at(1).props().className).toEqual('aClassName');
   });
 
   it('should merge style from context and props', () => {
@@ -153,7 +153,7 @@ describe('createSkeletonElement', () => {
     )(createSkeletonElement('div', { backgroundColor: 'grey' }));
     const wrapper = mount(<DivWithContext />);
 
-    expect(wrapper.find('div').props().style).toEqual({
+    expect(wrapper.find('div').at(1).props().style).toEqual({
       color: 'grey',
       backgroundColor: 'grey'
     });
@@ -172,6 +172,23 @@ describe('createSkeletonElement', () => {
     )(createSkeletonElement('div'));
     const wrapper = mount(<DivWithContext />);
 
-    expect(wrapper.find('div').props()['aria-hidden']).toEqual(true);
+    expect(wrapper.find('div').at(1).props()['aria-hidden']).toEqual(true);
+  });
+
+  it('should attach a displayName', () => {
+    const Comp: React.StatelessComponent = () => <div />;
+    expect(createSkeletonElement(Comp).displayName).toBe('Comp');
+
+    const CompWithDisplayName: React.StatelessComponent = () => <div />;
+    CompWithDisplayName.displayName = 'ParagraphComp';
+    expect(createSkeletonElement(CompWithDisplayName).displayName).toBe(
+      'ParagraphComp'
+    );
+
+    expect(createSkeletonElement('div').displayName).toBe('div');
+
+    expect(createSkeletonElement(() => <div />).displayName).toBe(
+      'SkeletorComponent'
+    );
   });
 });

--- a/src/__tests__/utils.test.tsx
+++ b/src/__tests__/utils.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { getComponentName } from '../utils';
+
+describe('getComponentName', () => {
+  let MyComponent;
+  beforeEach(() => {
+    MyComponent = () => <div />;
+  });
+
+  it('should default to the component displayName', () => {
+    MyComponent.displayName = 'Foo';
+
+    expect(getComponentName(MyComponent)).toEqual('Foo');
+  });
+
+  it('should fall back to the class name if displayName is empty', () => {
+    expect(getComponentName(MyComponent)).toEqual('MyComponent');
+  });
+
+  it('should ultimately fall back to "SkeletorComponent"', () => {
+    Object.defineProperty(MyComponent, 'name', {
+      value: ''
+    });
+
+    expect(getComponentName(MyComponent)).toEqual('SkeletorComponent');
+  });
+});

--- a/src/createSkeletonElement.ts
+++ b/src/createSkeletonElement.ts
@@ -3,7 +3,7 @@
 * See LICENSE.txt in the project root for license information.
 */
 import * as React from 'react';
-import { contextTypes, Context, Styling } from './utils';
+import { contextTypes, Context, getComponentName, Styling } from './utils';
 
 const createStyle = (styles: (React.CSSProperties | undefined)[]) =>
   styles
@@ -29,7 +29,7 @@ export interface InjectedProps {
 
 // tslint:disable-next-line:no-any
 export const createSkeletonElement = <T = any>(
-  type: React.SFC<T> | string,
+  type: React.ComponentType<T> | string,
   pendingStyle?: Styling
 ) => {
   const ExportedComponent: React.StatelessComponent<T> = (
@@ -62,6 +62,8 @@ export const createSkeletonElement = <T = any>(
   };
 
   ExportedComponent.contextTypes = contextTypes;
+  ExportedComponent.displayName =
+    typeof type === 'string' ? type : getComponentName(type);
 
   return ExportedComponent;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,3 +38,6 @@ export const contextTypes = {
     ])
   })
 };
+
+export const getComponentName = (type: React.ComponentType): string =>
+  type.displayName || type.name || 'SkeletorComponent';


### PR DESCRIPTION
## Description
Attach the displayName property to skeleton elements so they can be easily "found" with testing libs such as enzyme.


## Addressed issue
#17 
