### PR TITLE
Change type argument from SFC to ComponentType

### DIFF
--- a/src/createSkeletonElement.ts
+++ b/src/createSkeletonElement.ts
@@ -29,7 +29,7 @@ export interface InjectedProps {
 
 // tslint:disable-next-line:no-any
 export const createSkeletonElement = <T = any>(
-  type: React.SFC<T> | string,
+  type: React.ComponentType<T> | string,
   pendingStyle?: Styling
 ) => {
   const ExportedComponent: React.StatelessComponent<T> = (


### PR DESCRIPTION


## Description
Change type argument from SFC to ComponentType because the exact component type is of no relevance to skeletor.

## Addressed issue
#19
